### PR TITLE
Fix WebGL shader loop initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,10 @@ Then visit `http://localhost:8000/index.html`.
 
 ## Troubleshooting
 
-If the WebGL canvas only shows a white screen, open the browser's developer
-console and check for shader compilation errors. One common issue is an empty
-initializer in the fragment shader loop. The loop counter must be assigned in
-the `for` statement, as shown in `mandelbrot.js`:
+If the WebGL canvas only shows a white screen, open the browser's developer console and check for shader compilation errors. One common issue is an empty initializer in the fragment shader loop. The loop counter must be declared and assigned in the `for` statement, as shown in `mandelbrot.js`:
 
 ```glsl
-int iter = 0;
-for (iter = 0; iter < 1000; iter++) {
+for (int iter = 0; iter < 1000; iter++) {
     if (iter >= u_iter || dot(z, z) > 4.0) break;
     z = vec2(z.x*z.x - z.y*z.y, 2.0*z.x*z.y) + c;
 }

--- a/mandelbrot.js
+++ b/mandelbrot.js
@@ -58,8 +58,7 @@ void main() {
     vec2 uv = (gl_FragCoord.xy / u_resolution - 0.5) * u_scale;
     vec2 c = uv + u_center;
     vec2 z = vec2(0.0);
-    int iter = 0;
-    for (iter = 0; iter < 1000; iter++) {
+    for (int iter = 0; iter < 1000; iter++) {
         if (iter >= u_iter || dot(z, z) > 4.0) break;
         z = vec2(z.x*z.x - z.y*z.y, 2.0*z.x*z.y) + c;
     }


### PR DESCRIPTION
## Summary
- correct the fragment shader loop initializer
- clarify README troubleshooting snippet about shader loop

## Testing
- `python mandelbrot_zoom.py`

------
https://chatgpt.com/codex/tasks/task_e_683fa72238f083288caea32872411b64